### PR TITLE
Update snippet to include Render

### DIFF
--- a/snippets/liquid.json
+++ b/snippets/liquid.json
@@ -173,6 +173,20 @@
             "{% include '${1:snippet}', ${2:variable}: ${3:value} %}"
         ]
     },
+    "Tag render": {
+        "prefix": "render",
+        "description": "Theme tag: render",
+        "body": [
+            "{% render '${1:snippet}' %}"
+        ]
+    },
+    "Tag render with parameters": {
+        "prefix": "renderwith",
+        "description": "Theme tag: render with parameters",
+        "body": [
+            "{% render '${1:snippet}', ${2:variable}: ${3:value} %}"
+        ]
+    },
     "Tag section": {
         "prefix": "section",
         "description": "Theme tag: section",


### PR DESCRIPTION
See additional information on Render here: https://help.shopify.com/en/themes/liquid/tags/theme-tags#render

The include tag is still available for use but has been deprecated.